### PR TITLE
update monthly query to pull from risk score table

### DIFF
--- a/src/controllers/providerData.ts
+++ b/src/controllers/providerData.ts
@@ -10,10 +10,10 @@ export type MonthlyProviderData = {
   provider_licensing_id: string;
   provider_name: string;
   StartOfMonth: string; // ISO DateString
-  billed_over_capacity_flag: boolean;
-  placed_over_capacity_flag: boolean;
-  same_address_flag: boolean;
-  distance_traveled_flag: boolean;
+  over_billed_capacity: boolean;
+  over_placement_capacity: number;
+  same_address_flag: number;
+  distance_traveled_flag: number;
   is_flagged: boolean;
   comment: string;
   postal_address: string;
@@ -508,7 +508,7 @@ export async function getProviderMonthData(req: express.Request, res: express.Re
   try {
     const rawData: MonthlyProviderData[] = await queryData(text, namedParameters);
     // add overall risk score
-    const riskScoreKeys = ["billed_over_capacity_flag", "placed_over_capacity_flag", "same_address_flag", "distance_traveled_flag"] as const;
+    const riskScoreKeys = ["over_billed_capacity", "over_placement_capacity", "same_address_flag", "distance_traveled_flag"] as const;
     const result: UiMonthlyProviderData[] = rawData.map((item) => {
       const overallRiskScore = riskScoreKeys.reduce((sum, key) => sum + (item[key] ? 1 : 0), 0);
 
@@ -516,8 +516,8 @@ export async function getProviderMonthData(req: express.Request, res: express.Re
         providerLicensingId: item.provider_licensing_id,
         startOfMonth: item.StartOfMonth,
         providerName: item.provider_name,
-        childrenBilledOverCapacity: item.billed_over_capacity_flag ? "Yes" : "--",
-        childrenPlacedOverCapacity: item.placed_over_capacity_flag ? "Yes" : "--",
+        childrenBilledOverCapacity: item.over_billed_capacity ? "Yes" : "--",
+        childrenPlacedOverCapacity: item.over_placement_capacity ? "Yes" : "--",
         distanceTraveled: item.distance_traveled_flag ? "Yes" : "--",
         providersWithSameAddress: item.same_address_flag ? "Yes" : "--",
         overallRiskScore,

--- a/src/queryBuilders/providerMonthly.ts
+++ b/src/queryBuilders/providerMonthly.ts
@@ -33,33 +33,24 @@ export function parseOffsetParam(offsetParam: string): number {
 }
 
 export function buildProviderMonthlyQuery({ month, offset, isFlagged, cities }: BuildProviderMonthlyQueryParams) {
-  const query = SQL`
+
+  const query= SQL`
   SELECT rp.provider_licensing_id,
   rp.provider_name,
   dates.StartOfMonth,
-  boc.billed_over_capacity_flag,
-  poc.placed_over_capacity_flag,
-  sa.same_address_flag,
-  dt.distance_traveled_flag,
+  dates.over_billed_capacity,
+  dates.over_placement_capacity,
+  dates.same_address_flag,
+  dates.distance_traveled_flag,
   pi.is_flagged,
   pi.comment,
   a.postal_address,
   a.city,
   a.zip
   FROM (
-      SELECT provider_licensing_id, StartOfMonth from cusp_audit.demo.monthly_billed_over_capacity WHERE StartOfMonth = :month
-      UNION
-      SELECT provider_licensing_id, StartOfMonth from cusp_audit.demo.monthly_placed_over_capacity WHERE StartOfMonth = :month
-      UNION
-      SELECT provider_licensing_id, StartOfMonth from cusp_audit.demo.monthly_providers_with_same_address WHERE StartOfMonth = :month
-      UNION
-      SELECT provider_licensing_id, StartOfMonth from cusp_audit.demo.monthly_distance_traveled WHERE StartOfMonth = :month
+      SELECT provider_licensing_id, StartOfMonth, over_placement_capacity, same_address_flag, distance_traveled_flag, over_billed_capacity, same_address_flag from cusp_audit.demo.risk_scores WHERE StartOfMonth = :month
   ) AS dates
   JOIN cusp_audit.demo.risk_providers rp ON rp.provider_licensing_id = dates.provider_licensing_id
-  LEFT JOIN cusp_audit.demo.monthly_billed_over_capacity boc ON boc.provider_licensing_id = dates.provider_licensing_id AND boc.StartOfMonth = dates.StartOfMonth
-  LEFT JOIN cusp_audit.demo.monthly_placed_over_capacity poc ON poc.provider_licensing_id = dates.provider_licensing_id AND  poc.StartOfMonth = dates.StartOfMonth
-  LEFT JOIN cusp_audit.demo.monthly_providers_with_same_address sa ON sa.provider_licensing_id = dates.provider_licensing_id AND sa.StartOfMonth = dates.StartOfMonth
-  LEFT JOIN cusp_audit.demo.monthly_distance_traveled dt ON dt.provider_licensing_id = dates.provider_licensing_id AND dt.StartOfMonth = dates.StartOfMonth
   LEFT JOIN cusp_audit.demo.provider_insights pi ON rp.provider_licensing_id = pi.provider_licensing_id
   LEFT JOIN cusp_audit.fake_data.addresses a ON rp.provider_address_uid = a.provider_address_uid
   WHERE 1=1`;


### PR DESCRIPTION
Should address:

Sr No | Priority | Status | Description
-- | -- | -- | --
1 | High |   | Column header allignment with column values - could we make all column values left alligned with column header?
  |   |   |  
2 | High |   | There are a bunch of providers who scored 48 on the annual view, i.e. they were flagged on all 4 categories for past 12 months. But lot of them don't appear in the monthly view. One example is "KnowledgePoints Learning Academy". I checked the backend, "KnowledgePoints Learning Academy" was flagged for all 12 months in 2024 in the backend table too (see screenshot). So it should appear on the monthly view on the front end.
  |   |   |  
3 | Medium |   | Can't flag providers on annual view
  |   |   |  
4 | Medium |   | "Flagged" filter on monthly view showing incorrect results
